### PR TITLE
Simplified passing of common headers during intialization

### DIFF
--- a/lib/tvdb_client/series.rb
+++ b/lib/tvdb_client/series.rb
@@ -1,7 +1,7 @@
 module TVDB
   class Series
     attr_accessor :connection
-    attr_reader   :data, :route, :series_id
+    attr_reader   :data, :route, :series_id, :code
 
     def initialize( connection, series_id, options = {} )
       @connection = connection
@@ -27,6 +27,7 @@ module TVDB
     def get_series( series_id, options = {} )
       series = connection.get( route, options )
       @data  = series.body
+      @code  = series.code
     end
   end
 end

--- a/spec/support/fake_TVDB.rb
+++ b/spec/support/fake_TVDB.rb
@@ -21,6 +21,10 @@ class FakeTVDB < Sinatra::Base
     series_routes( request, params["id"], 'responses/series.json')
   end
 
+  get '/not/modified' do
+    not_modified_response
+  end
+
   get '/series/:id/episodes' do
     page = params["page"]
 
@@ -79,6 +83,12 @@ class FakeTVDB < Sinatra::Base
     content_type :json
     status 404
     "{\"Error\": \"ID: #{id} not found\"}"
+  end
+
+  def not_modified_response
+    content_type :json
+    status 304
+    ""
   end
 
   def bad_auth_header?( request )

--- a/spec/tvdb_client/connection_spec.rb
+++ b/spec/tvdb_client/connection_spec.rb
@@ -125,6 +125,13 @@ describe "TVDB::Connection" do
           expect( subject.get( '/series/1234' ).code ).to be( 401 )
         end
       end
+
+      context '304 response' do
+        it "should an empty body for a 304 (not modified) response" do
+          expect( subject.get( '/not/modified' ).code ).to be( 304 )
+          expect( subject.get( '/not/modified' ).body ).to be( nil )
+        end
+      end
     end
     
   end


### PR DESCRIPTION
**Case:** N/A
**Description:** Allow the user to set the default language, version, and
'if-modified-since' header when setting up a new TVDB::Client. These values
are all optional, but will persist through the life of the object so that you
do not have to pass in a :header hash with each request.
